### PR TITLE
Allow extending build tags in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,24 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 TENDERMINT_VERSION := $(shell go list -m github.com/tendermint/tendermint | sed 's:.* ::')
 
-BUILD_TAGS := $(strip netgo,ledger)
+build_tags := netgo ledger
+build_tags += ${BUILD_TAGS}
+build_tags := $(strip ${build_tags})
+
+empty :=
+whitespace += ${empty} ${empty}
+comma := ,
+build_tags_comma_sep := $(subst ${whitespace},${comma},${build_tags})
+
 LD_FLAGS := -s -w \
     -X github.com/cosmos/cosmos-sdk/version.Name=comdex \
     -X github.com/cosmos/cosmos-sdk/version.AppName=comdex \
     -X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
     -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
-    -X github.com/cosmos/cosmos-sdk/version.BuildTags=${BUILD_TAGS} \
+    -X github.com/cosmos/cosmos-sdk/version.BuildTags=${build_tags_comma_sep} \
     -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TENDERMINT_VERSION)
 
-BUILD_FLAGS += -ldflags "${LD_FLAGS}" -tags "${BUILD_TAGS}"
+BUILD_FLAGS += -ldflags "${LD_FLAGS}" -tags "${build_tags}"
 
 GOBIN = $(shell go env GOPATH)/bin
 GOARCH = $(shell go env GOARCH)


### PR DESCRIPTION
This PR allows to pass additional build tags in `Makefile`.

We more or less reused the same code as in [osmosis Makefile](https://github.com/osmosis-labs/osmosis/blob/a5589e0f0fb841d30f86930a4248cdec25632282/Makefile)

Passing additional tag is useful for building a _**static**_ comdex binary (that has `cosmvm` statically linked). 

Example: (using an alpine container for muslc usage instead of glibc):

```bash
docker run -ti golang:1.16-alpine3.15 /bin/sh
```

```bash
apk add git gcc build-base linux-headers

# libwasmvm should match wasmvm version of project
wget https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta5/libwasmvm_muslc.a -O /lib/libwasmvm_muslc.a

git clone https://github.com/comdex-official/comdex.git
cd comdex
git checkout v0.1.1
BUILD_TAGS=muslc make build

file /go/bin/comdex
ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=zc-RP82g02fXfxgf2o_E/HB4ukZXr0DZYdFAP-bQp/T30zGVELtINRzB2AB11C/zbyB4TxW2FpS_3eHZZll, stripped
```

The important part is the `BUILD_TAGS=muslc` additional tag.