### PR TITLE
Active farmer set bug fix

### DIFF
--- a/x/liquidity/keeper/rewards.go
+++ b/x/liquidity/keeper/rewards.go
@@ -401,7 +401,11 @@ func (k Keeper) Unfarm(ctx sdk.Context, msg *types.MsgUnfarm) error {
 	}
 
 	if aFarmerUpdated {
-		k.SetActiveFarmer(ctx, activeFarmer)
+		if activeFarmer.FarmedPoolCoin.IsZero() {
+			k.DeleteActiveFarmer(ctx, activeFarmer)
+		} else {
+			k.SetActiveFarmer(ctx, activeFarmer)
+		}
 	}
 	k.SetQueuedFarmer(ctx, queuedFarmer)
 

--- a/x/liquidity/keeper/rewards_test.go
+++ b/x/liquidity/keeper/rewards_test.go
@@ -453,9 +453,7 @@ func (s *KeeperTestSuite) TestUnfarmTwo() {
 	afs = s.keeper.GetAllActiveFarmers(s.ctx, appID1, pool.Id)
 	qfs = s.keeper.GetAllQueuedFarmers(s.ctx, appID1, pool.Id)
 	s.Require().Len(qfs[0].QueudCoins, 0)
-	s.Require().Len(afs, 1)
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Denom, afs[0].FarmedPoolCoin.Denom)
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Amount, afs[0].FarmedPoolCoin.Amount)
+	s.Require().Len(afs, 0)
 
 	s.Require().True(utils.ParseCoins("10000000000pool1-1").IsEqual(s.getBalances(liquidityProvider1)))
 
@@ -604,12 +602,12 @@ func (s *KeeperTestSuite) TestUnfarmTwo() {
 	s.Require().Len(qfs, 2)
 	s.Require().Len(qfs[1].QueudCoins, 0)
 	s.Require().Len(qfs[0].QueudCoins, 0)
-	s.Require().Len(afs, 2)
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Denom, afs[0].FarmedPoolCoin.Denom)
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Amount, afs[0].FarmedPoolCoin.Amount)
+	s.Require().Len(afs, 0)
+	// s.Require().Equal(utils.ParseCoin("0pool1-1").Denom, afs[0].FarmedPoolCoin.Denom)
+	// s.Require().Equal(utils.ParseCoin("0pool1-1").Amount, afs[0].FarmedPoolCoin.Amount)
 
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Denom, afs[1].FarmedPoolCoin.Denom)
-	s.Require().Equal(utils.ParseCoin("0pool1-1").Amount, afs[1].FarmedPoolCoin.Amount)
+	// s.Require().Equal(utils.ParseCoin("0pool1-1").Denom, afs[1].FarmedPoolCoin.Denom)
+	// s.Require().Equal(utils.ParseCoin("0pool1-1").Amount, afs[1].FarmedPoolCoin.Amount)
 
 	s.Require().True(utils.ParseCoins("10000000000pool1-1").IsEqual(s.getBalances(liquidityProvider1)))
 	s.Require().True(utils.ParseCoins("9999999999pool1-1").IsEqual(s.getBalances(liquidityProvider2)))

--- a/x/liquidity/keeper/store.go
+++ b/x/liquidity/keeper/store.go
@@ -625,6 +625,12 @@ func (k Keeper) SetActiveFarmer(ctx sdk.Context, activeFarmer types.ActiveFarmer
 	store.Set(types.GetActiveFarmerKey(activeFarmer.AppId, activeFarmer.PoolId, sdk.MustAccAddressFromBech32(activeFarmer.Farmer)), bz)
 }
 
+// DeleteActiveFarmer deletes a Active farmer from store.
+func (k Keeper) DeleteActiveFarmer(ctx sdk.Context, activeFarmer types.ActiveFarmer) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.GetActiveFarmerKey(activeFarmer.AppId, activeFarmer.PoolId, sdk.MustAccAddressFromBech32(activeFarmer.Farmer)))
+}
+
 // GetActiveFarmer returns active farmer object for the given app id, pool id and farmer.
 func (k Keeper) GetActiveFarmer(ctx sdk.Context, appID, poolID uint64, farmer sdk.AccAddress) (activeFarmer types.ActiveFarmer, found bool) {
 	store := ctx.KVStore(k.storeKey)

--- a/x/liquidity/types/farm.go
+++ b/x/liquidity/types/farm.go
@@ -29,10 +29,10 @@ func (activeFarmer ActiveFarmer) Validate() error {
 		return fmt.Errorf("invalid farmer address %s: %w", activeFarmer.Farmer, err)
 	}
 	if err := activeFarmer.FarmedPoolCoin.Validate(); err != nil {
-		return fmt.Errorf("invalid offer coin %s: %w", activeFarmer.FarmedPoolCoin, err)
+		return fmt.Errorf("invalid farmed-pool-coin %s: %w", activeFarmer.FarmedPoolCoin, err)
 	}
 	if activeFarmer.FarmedPoolCoin.IsZero() {
-		return fmt.Errorf("offer coin must not be 0")
+		return fmt.Errorf("farmed-pool-coin must not be 0")
 	}
 	return nil
 }

--- a/x/liquidity/types/genesis.go
+++ b/x/liquidity/types/genesis.go
@@ -136,16 +136,18 @@ func (genState GenesisState) Validate() error {
 		}
 		activeFarmerMap := map[string]ActiveFarmer{}
 		for i, activeFarmer := range appState.ActiveFarmers {
-			if err := activeFarmer.Validate(); err != nil {
-				return fmt.Errorf("invalid active farmer at index %d: %w", i, err)
+			if activeFarmer.FarmedPoolCoin.IsPositive() {
+				if err := activeFarmer.Validate(); err != nil {
+					return fmt.Errorf("invalid active farmer at index %d: %w", i, err)
+				}
+				if _, ok := poolMap[activeFarmer.PoolId]; !ok {
+					return fmt.Errorf("active farmer at index %d has unknown pool id: %d", i, activeFarmer.PoolId)
+				}
+				if _, ok := activeFarmerMap[activeFarmer.Farmer]; ok {
+					return fmt.Errorf("active farmer at index %d has a duplicate farmer : %s", i, activeFarmer.Farmer)
+				}
+				activeFarmerMap[activeFarmer.Farmer] = activeFarmer
 			}
-			if _, ok := poolMap[activeFarmer.PoolId]; !ok {
-				return fmt.Errorf("active farmer at index %d has unknown pool id: %d", i, activeFarmer.PoolId)
-			}
-			if _, ok := activeFarmerMap[activeFarmer.Farmer]; ok {
-				return fmt.Errorf("active farmer at index %d has a duplicate farmer : %s", i, activeFarmer.Farmer)
-			}
-			activeFarmerMap[activeFarmer.Farmer] = activeFarmer
 		}
 
 		for i, queuedFarmer := range appState.QueuedFarmers {


### PR DESCRIPTION
Changes Include - 
1. After unfarm if the active-farmer has 0-poolcoin farmed, delete the object from the store.
2. Avoid active farmer objects whose farmed-pool-coin is 0 while importing the chain state from exported json.
3. Fix liquidity testcases.
