### PR TITLE
CV FIX: wasm snapshot

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1003,6 +1003,15 @@ func New(
 	app.SetAnteHandler(anteHandler)
 	app.SetEndBlocker(app.EndBlocker)
 
+	if manager := app.SnapshotManager(); manager != nil {
+		err = manager.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WasmKeeper),
+		)
+		if err != nil {
+			panic("failed to register snapshot extension: " + err.Error())
+		}
+	}
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(err.Error())


### PR DESCRIPTION
This patch specifically adds wasm to snapshots

In addition the following patches are required to fix snapshots and pruning until upstream repositories accept changes

```
git checkout https://github.com/chillyvee/comdex
cd comdex
git checkout cv5.0.0.fixsnap
go mod edit -replace github.com/cosmos/iavl=github.com/chillyvee/iavl@v0.19.4-blunt.3
go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/chillyvee/cosmos-sdk@cv0.45.9snap.2
go mod tidy
```